### PR TITLE
Updating validation report

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -77,7 +77,7 @@ the range of scenarios covered in the unittests of **adoptr** is
 rather limited.
 Furthermore, the current R unittesting framework does not permit 
 an easy generation of a human-readable report of the test cases
-to acertain coverage and test quality.
+to ascertain coverage and test quality.
 Therefore, **adoptr** splits testing in two parts: technical 
 correctness is ensured via an extensive unittesting suit in **adoptr**
 itself (aiming to maintain a 100% code coverage).
@@ -488,7 +488,8 @@ and expected sample sizes respectively by the **adoptr** routine `simulate`.
 Furthermore, global tolerances for the validation are set. 
 For error rates, a relative deviation of $1\%$ from the target value is 
 accepted. 
-(Expected) Sample sizes deviations are more liberally accepted up to $0.5$. 
+(Expected) Sample sizes deviations are more liberally accepted up to an 
+absolute deviation of $0.5$. 
 ```{r setup, results='hide'}
 library(adoptr)
 library(tidyverse)


### PR DESCRIPTION
I couldn't find everything in the source code that is why the other typos are listed here:
- Section 2.3.5: monotonously
- Section 3.1: regulatory
- Section 3.2.5: Additionally, expected sample sizes under the null hypothesis are computed ...
- Section 5.3.5: power constraints
- Section 6.5.5: average
A few other very small comments:
- l.81 in your source code: splits the testing into to parts: ... 
It seems as only one is mentioned.
- Section 1.4: sample size deviations ... up to an absolute deviation of 0.5
- authors names in the references are not handled in a common way